### PR TITLE
remove use of loops in string chapter before loops are introduced

### DIFF
--- a/src/chapters/strings/encoding-characters.rst
+++ b/src/chapters/strings/encoding-characters.rst
@@ -120,9 +120,17 @@ the character at that index.
 
       let nonprofit = "LaunchCode";
 
-      for (let i = 0; i < nonprofit.length; i++) {
-         console.log(nonprofit.charCodeAt(i));
-      }
+      console.log(nonprofit.charCodeAt(0));
+      console.log(nonprofit.charCodeAt(1));
+      console.log(nonprofit.charCodeAt(2));
+      console.log(nonprofit.charCodeAt(3));
+      console.log(nonprofit.charCodeAt(4));
+      console.log(nonprofit.charCodeAt(5));
+      console.log(nonprofit.charCodeAt(6));
+      console.log(nonprofit.charCodeAt(7));
+      console.log(nonprofit.charCodeAt(8));
+      console.log(nonprofit.charCodeAt(9));
+      
 
    **Console Output**
 
@@ -148,11 +156,12 @@ To convert an ASCII code to an actual character, use ``String.fromCharCode()``.
       :linenos:
 
       let codes = [76, 97, 117, 110, 99, 104, 67, 111, 100, 101];
-      let characters = "";
 
-      for (let i = 0; i < codes.length; i++) {
-         characters += String.fromCharCode(codes[i]);
-      }
+      let characters = String.fromCharCode(codes[0]) + String.fromCharCode(codes[1])
+                     + String.fromCharCode(codes[2]) + String.fromCharCode(codes[3])
+                     + String.fromCharCode(codes[4]) + String.fromCharCode(codes[5])
+                     + String.fromCharCode(codes[6]) + String.fromCharCode(codes[7])
+                     + String.fromCharCode(codes[8]) + String.fromCharCode(codes[9]);
 
       console.log(characters);
 


### PR DESCRIPTION
removes use of for loops from the strings section.
closes #228 