### PR TITLE
Fixes Dom and Events Exercises

### DIFF
--- a/src/chapters/dom-and-events/event-types.rst
+++ b/src/chapters/dom-and-events/event-types.rst
@@ -8,8 +8,8 @@ As you continue your studies of the DOM and events, you may find these two refer
 2. `MDN Event reference <https://developer.mozilla.org/en-US/docs/Web/Events>`_
 
 
-Load Event
-----------
+``load`` Event
+--------------
 
 .. index::
    single: event; load
@@ -19,13 +19,13 @@ been *loaded* by the browser. Why is it important to know when things have loade
 interact with HTML elements in JavaScript unless they have been loaded into the DOM.
 
 Previously, we were moving the ``<script>`` element *below* any HTML elements that we needed
-to reference in the DOM. Using the *load event* on the global variable ``window`` is an
-alternative to ``<script>`` placement. When the *load event* has triggered on the *window* as
+to reference in the DOM. Using the ``load`` event on the global variable ``window`` is an
+alternative to ``<script>`` placement. When the ``load`` event has triggered on the ``window`` as
 a whole, we can know that all the elements are ready to be used.
 
 .. admonition:: Example
 
-   A ``<script>`` tag is in ``<header>`` and all DOM code is inside *load* event handler.
+   A ``<script>`` tag is in ``<header>`` and all DOM code is inside ``load`` event handler.
 
    .. sourcecode:: html
       :linenos:
@@ -68,20 +68,19 @@ a whole, we can know that all the elements are ready to be used.
       knock knock
 
 
-Mouseover Event
----------------
+``mouseover`` and ``mouseout`` Events
+-------------------------------------
 
 .. index::
    single: event; mouseover
 
-There are many mouse related DOM events. We have already used the *click* event. Another example
-of a mouse event is the **mouseover** event, which is triggered when the mouse pointer enters
+There are many mouse related DOM events. We have already used the ``click`` event. Another example
+of a mouse event is the **mouseover event**, which is triggered when the mouse cursor enters
 an element.
 
 .. admonition:: Example
 
-   We can use *mouseover* event to add a ``">"`` to the ``innerHTML`` of the element that the mouse pointer
-   has been moved over.
+   We can use ``mouseover`` event to add a ``">"`` to the ``innerHTML`` of the element that the mouse cursor has been moved over.
 
    .. sourcecode:: html
       :linenos:
@@ -121,18 +120,23 @@ an element.
          Lane 2>>>>>>>>>>>>
          Lane 3>>>>>>>>
 
+.. index::
+   single: event; mouseout
+
+Similarly, there is a **mouseout event** that is triggered when the cursor leaves a given element.
+
 
 Check Your Understanding
 ------------------------
 
 .. admonition:: Question
 
-   What error happens when you try to access an element that has not been loaded into the DOM?
+   Which error occurs when you try to access an element that has not been loaded into the DOM?
 
 
 .. admonition:: Question
 
-   What is *true* when the *load* event is triggered on ``window``?
+   What is *true* when the ``load`` event is triggered on ``window``?
 
    a. The console is clear.
    b. All elements and resources have been loaded by the browser.

--- a/src/chapters/dom-and-events/exercises.rst
+++ b/src/chapters/dom-and-events/exercises.rst
@@ -7,10 +7,7 @@ the requirements and desired effect of the events is listed.
 
 `Repl.it with starter code <https://repl.it/@launchcode/Exercises-DOM-and-Events>`__
 
-#. When the *Take off* button is clicked, the text ``The shuttle is on the
-   ground`` changes to ``Houston, we have lift off!``. The *Take off* button
-   has an ``id="liftoffButton"`` attribute.
-#. When the user's mouse goes over the *Abort Mission* button, the button's
-   background turns red. The *Abort Mission* button has ``id="abortMission"``.
-#. When the user clicks the *Abort Mission* button, make a confirmation window
-   that says ``Are you sure you want to abort the mission?``
+#. When the *Take off* button is clicked, the text ``The shuttle is on the ground`` changes to ``Houston, we have liftoff!``. The *Take off* button has an ``id="liftoffButton"`` attribute.
+#. When the user's cursor goes over the *Abort Mission* button, the button's background turns red. The *Abort Mission* button has ``id="abortMission"``.
+#. When the user's cursor *leaves* the *Abort Mission* button, the button's background returns to its original state (*Hint:* Setting the background color to the empty string, ``""``, will force it to revert to the default browser styles.)
+#. When the user clicks the *Abort Mission* button, make a confirmation window that says ``Are you sure you want to abort the mission?``. If the user confirms that they want to abort, the text changes to ``Mission aborted! Space shuttle returning home``.


### PR DESCRIPTION
Fixes #315 and makes a few additional improvements to the chapter. In particular, I added an additional step to the exercises that has students add a `mouseout` event handler. I also briefly introduced this event in the previous section.

[Updated starter code](https://repl.it/@launchcode/Exercises-DOM-and-Events#script.js)

[Update solution MR](https://gitlab.com/LaunchCodeEducation/lc101-solutions-unit1/-/merge_requests/13)